### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/sorescuc/0eff284e-e797-469f-9c99-634d6f50aefd/b2a82568-2565-4c6d-b957-61b0b5916788/_apis/work/boardbadge/58c727a6-8142-42a5-bb9b-a1636bc484f2)](https://dev.azure.com/sorescuc/0eff284e-e797-469f-9c99-634d6f50aefd/_boards/board/t/b2a82568-2565-4c6d-b957-61b0b5916788/Microsoft.RequirementCategory)
 # hello-world
 this is a simple repo. please ingore it
 


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/sorescuc/0eff284e-e797-469f-9c99-634d6f50aefd/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.